### PR TITLE
Attempt to make using the repo easier for outsiders

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We try to update the database daily. However, as we add more and more datapoints
 
 ## Replication Code
 
-See README file for detailed instructions. 
+See [README](<Replication Codes/README.md>) file in  for detailed instructions. 
 
 ## Source of the Data
 
@@ -24,3 +24,22 @@ The original data are collected by the John Hopkins CSSE team and are publicly a
 ## Questions?
 
 You can write an email to simas [dot] kucinskas [at] hu [dash] berlin [dot] de – all comments and suggestions are most welcome.
+
+## Install Requirements
+
+Before installing, to use the most recent version of `pip` (21.3.1 at the time
+of this writing). To upgrade pip on a Linux system, run
+
+    sudo -H pip install --upgrade pip
+
+You could use a virtual environment, install the dependencies to your user or
+make a system-wide installation.
+To install all required dependencies to your current user, execute
+
+    pip install -r requirements.txt --upgrade --user
+
+If you want to install the dependencies system-wide, run
+
+    sudo -H pip install -r requirements.txt
+
+instead.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+matplotlib==3.5.1
+numpy==1.22.0
+pandas==1.3.5
+pillow==9.0.0
+pystan==2.19.1.1
+scikit_learn==1.0.2
+scipy==1.7.3
+seaborn==0.11.2
+statsmodels==0.13.1


### PR DESCRIPTION
added a requirements file and some documentation

note: the version of pystan used is fairly outdated; tried a new version, but that would need some code changes as well
(ie simply using `import stan as pystan` and falling back to older installed versions would not work b/c of API changes).